### PR TITLE
7z output only UTF-8 encode

### DIFF
--- a/lzmadec.go
+++ b/lzmadec.go
@@ -191,7 +191,7 @@ func NewArchive(path string) (*Archive, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command("7z", "l", "-slt", path)
+	cmd := exec.Command("7z", "l", "-slt", "-sccUTF-8", path)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Always output 7z in UTF-8 encode. Error found in windows in russian languages.