### PR TITLE
add missing error handler

### DIFF
--- a/lzmadec.go
+++ b/lzmadec.go
@@ -270,6 +270,10 @@ func (a *Archive) GetFileReader(name string) (io.ReadCloser, error) {
 
 	cmd := exec.Command("7z", params...)
 	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
 	rc := &readCloser{
 		rc:  stdout,
 		cmd: cmd,


### PR DESCRIPTION
fixup panic:
```
INFO[2019-08-15 11:41:28] Extracting 603 entries
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4fb3a6]

goroutine 251 [running]:
github.com/kjk/lzmadec.(*Archive).GetFileReader(0xc000116090, 0xc0001a8c67, 0x26, 0x18, 0xc0004225d8, 0xc000422650, 0x4aff7f)
	/home/user/go/pkg/mod/github.com/kjk/lzmadec@v0.0.0-20190802150927-78d187673998/lzmadec.go:279 +0x226
github.com/kjk/lzmadec.(*Archive).ExtractToWriter(0xc000116090, 0x8c69e0, 0xc0003a20b0, 0xc0001a8c67, 0x26, 0x0, 0x0)
	/home/user/go/pkg/mod/github.com/kjk/lzmadec@v0.0.0-20190802150927-78d187673998/lzmadec.go:287 +0x4c
github.com/kjk/lzmadec.(*Archive).ExtractToFile(0xc000116090, 0xc0001a8c67, 0x26, 0xc0001a8c67, 0x26, 0x0, 0x0)
	/home/user/go/pkg/mod/github.com/kjk/lzmadec@v0.0.0-20190802150927-78d187673998/lzmadec.go:306 +0xc9
```