### PR TITLE
Do not consume stderr.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/kjk/lzmadec

--- a/lzmadec.go
+++ b/lzmadec.go
@@ -216,7 +216,7 @@ func newArchive(path string, password *string) (*Archive, error) {
 	params = append(params, fmt.Sprintf("-p%s", tmpPassword))
 	params = append(params, path)
 	cmd := exec.Command("7z", params...)
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
That allows caller to inspect `err.(*exec.ExitError).Stderr`.

Also, add go.mod.