### PR TITLE
More formats supported - less strict 7z output checks

### DIFF
--- a/lzmadec.go
+++ b/lzmadec.go
@@ -109,10 +109,8 @@ func getEntryLines(scanner *bufio.Scanner) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(res) == 9 || len(res) == 0 {
-		return res, nil
-	}
-	return nil, errUnexpectedLines
+
+	return res, nil
 }
 
 func parseEntryLines(lines []string) (Entry, error) {
@@ -150,8 +148,6 @@ func parseEntryLines(lines []string) (Entry, error) {
 			e.Method = v
 		case "block":
 			e.Block, err = strconv.Atoi(v)
-		default:
-			err = fmt.Errorf("unexpected entry line '%s'", name)
 		}
 		if err != nil {
 			return e, err


### PR DESCRIPTION
Hi,

I'd like to extract also rar archives using this library. 7z is capable of this, but rar has more attributes in `7z l` output. Namely 17 instead of 9.

Thus I removed the lines count check and I'm also ignoring unknown attributes in `parseEntryLines`. Then rar file can be sucessfully extracted. I removed it instead of adding rar attributes to not block possible other formats with arbitrary number of attributes supported by 7zip.

As a safety replacement, I can add check of mandatory attributes (i.e. if Path was present for example), if you are interested.

Regards